### PR TITLE
Fix remote code execution vulnerability

### DIFF
--- a/pyqq/api.py
+++ b/pyqq/api.py
@@ -4,7 +4,7 @@ import re
 import time
 from rest import Get,Post
 from algorithm import pwd_encode,get_clientid,get_msgid
-from  Cookie import SmartCookie as Cookie
+from  Cookie import SimpleCookie as Cookie
 from utils import getcookiestr
 import urllib
 import json 

--- a/pyqq/utils.py
+++ b/pyqq/utils.py
@@ -1,6 +1,6 @@
 import unittest
 import unittest
-from  Cookie import SmartCookie as Cookie
+from  Cookie import SimpleCookie as Cookie
 
 def getcookiestr(cookie):
 	items = []


### PR DESCRIPTION
If ptlogin2.qq.com is evil it is able to execute code on your clients.

SmartCookie as well as SerialCookie are vulnerable to code injection in python2.
For example, the following cookie header would shutdown your client:
Set-Cookie: foo="cposix\012_exit\012p1\012(I1\012tp2\012Rp3\012."
